### PR TITLE
Drain volumeattachments before node reboot

### DIFF
--- a/kube-merit-updater
+++ b/kube-merit-updater
@@ -162,6 +162,14 @@ drain_node() {
   fi
 }
 
+drain_volumeattachments() {
+  local node=$1
+
+  for va in $(retry kubectl --context="${kube_context}" get volumeattachment | grep ${node} | awk '{print $1}'); do
+    retry kubectl --context="${kube_context}" delete volumeattachment ${va}
+  done
+}
+
 reboot_node() {
   local node=$1
 
@@ -200,6 +208,7 @@ cycle_nodes() {
     jq -r '.items[].metadata.name')
   for node in ${nodes}; do
     drain_node ${node}
+    drain_volumeattachments ${node}
     reboot_node ${node}
     wait_for_ready_node ${node}
     delete_retirement_label ${node}
@@ -219,6 +228,7 @@ resume() {
     jq -r '.items[].metadata.name')
   for target_node in ${target_nodes}; do
     drain_node ${target_node}
+    drain_volumeattachments ${target_node}
     reboot_node ${target_node}
     wait_for_ready_node ${target_node}
     delete_retirement_label ${target_node}


### PR DESCRIPTION
Otherwise kube might not be able to relocate the attachment to a new node before
reboot and the volume is stuck there until the node comes up and kubelet can
respond