### PR TITLE
Roll nodes concurrently

### DIFF
--- a/kube-merit-updater
+++ b/kube-merit-updater
@@ -56,6 +56,11 @@ while getopts 'hc:r:s:t:p:n:' flag; do
 done
 
 ### Deps
+if [[ "${BASH_VERSINFO:-0}" -lt 4 ]]; then
+    echo "Bash version must be >=4"
+    exit 1
+fi
+
 deps="
   awk
   jq

--- a/kube-merit-updater
+++ b/kube-merit-updater
@@ -68,7 +68,7 @@ deps="
 
 missing_deps=""
 for d in ${deps}; do
-  if ! command -v ${d} &> /dev/null; then
+  if ! command -v "${d}" &> /dev/null; then
     missing_deps+="${d} "
   fi
 done
@@ -112,7 +112,7 @@ if [[ -z "${role}" ]] ; then
 fi
 
 function fail() {
-  echo $1 >&2
+  echo "$1" >&2
   exit 1
 }
 
@@ -121,7 +121,9 @@ function retry() {
   local max=12
   local delay=8
   while true; do
-    "$@" && break || {
+    if "$@"; then
+      break
+    else
       if [[ $n -lt $max ]]; then
         ((n++))
         echo "command failed: attempt=$n max=$max"
@@ -129,7 +131,7 @@ function retry() {
       else
         fail "the command has failed after $n attempts."
       fi
-    }
+    fi
   done
 }
 
@@ -137,27 +139,27 @@ label_for_cycling() {
   local role=$1
   local nodes=""
   while [[ -z "${nodes}" ]]; do
-    nodes=$(retry kubectl --context=${kube_context} get nodes -l role=${role} -o json | jq -r '.items[].metadata.name')
+    nodes=$(retry kubectl --context="${kube_context}" get nodes -l role="${role}" -o json | jq -r '.items[].metadata.name')
   done
 
   echo "${kube_context}: nodes=$(echo "${nodes}" | wc -l) role=${role}"
   echo "labelling for retirement: role=${role}"
   for node in ${nodes}; do
-    retry kubectl --context=${kube_context} label node ${node} retiring=${retire_time} --overwrite=true
+    retry kubectl --context="${kube_context}" label node "${node}" retiring="${retire_time}" --overwrite=true
   done
 }
 
 delete_retirement_label() {
   local node=$1
   echo "removing labelling for retirement: role=${role}"
-  retry kubectl --context=${kube_context} label node ${node} retiring-
+  retry kubectl --context="${kube_context}" label node "${node}" retiring-
 }
 
 delete_pods() {
   local node=$1
 
-  retry kubectl --context=${kube_context} get pod --all-namespaces \
-    -o jsonpath='{range .items[?(.spec.nodeName=="'${node}'")]}{@.metadata.namespace} {.metadata.name} {end}' |\
+  retry kubectl --context="${kube_context}" get pod --all-namespaces \
+    -o jsonpath="{range .items[?(.spec.nodeName==\"${node}\")]}{@.metadata.namespace} {.metadata.name} {end}" |\
     xargs -n2 |\
     xargs -I % sh -c "kubectl --context=${kube_context} delete pods -n=%"
 }
@@ -166,23 +168,23 @@ drain_node() {
   local node=$1
 
   set +e
-  time timeout --foreground ${timeout} kubectl --context=${kube_context} drain ${node} --ignore-daemonsets --force --delete-local-data
+  time timeout --foreground ${timeout} kubectl --context="${kube_context}" drain "${node}" --ignore-daemonsets --force --delete-local-data
   local rc=$?
   if [[ ${rc} -eq 0 ]]; then
     echo "drained successfully"
   elif [[ ${rc} -eq 124 ]]; then
     echo "timeout reached, continuing: timeout=${timeout}"
-    delete_pods ${node}
+    delete_pods "${node}"
   else
     echo "kubectl drain exit error: ${rc}"
-    delete_pods ${node}
+    delete_pods "${node}"
   fi
 }
 
 wait_until_volumeattachments_drained() {
   local node=$1
 
-  until [[ $(kubectl --context="${kube_context}" get volumeattachment | grep ${node} | wc -l) == 0 ]]; do
+  until [[ $(kubectl --context="${kube_context}" get volumeattachment | grep -c "${node}") == 0 ]]; do
     echo "Waiting for kubelet to detach all volumes from node: ${node}..."
     sleep 1
   done
@@ -193,13 +195,14 @@ reboot_node() {
 
   set +e
 
-  ssh -o ServerAliveInterval=1 -o ServerAliveCountMax=1 -o BatchMode=yes ${node} sudo reboot
+  ssh -o ServerAliveInterval=1 -o ServerAliveCountMax=1 -o BatchMode=yes "${node}" sudo reboot
 
-  local kube_active=$(ssh -oBatchMode=yes ${node} systemctl is-active kubelet.service)
+  local kube_active
+  kube_active=$(ssh -oBatchMode=yes "${node}" systemctl is-active kubelet.service)
   until [[ ${kube_active} == "active" ]]; do
     echo "awaiting node: ${node} to reboot and kubelet.service to become active"
     sleep 15
-    kube_active=$(ssh -oBatchMode=yes ${node} systemctl is-active kubelet.service)
+    kube_active=$(ssh -oBatchMode=yes "${node}" systemctl is-active kubelet.service)
   done
 }
 
@@ -208,24 +211,25 @@ wait_for_ready_node() {
 
   set +e
   # Wait for node to report ready again
-  local node_status=$(kubectl --context=${kube_context} get node | grep ${node} | awk '{print $2}')
+  local node_status
+  node_status=$(kubectl --context="${kube_context}" get node | grep "${node}" | awk '{print $2}')
   until [[ ${node_status} == "Ready,SchedulingDisabled" || ${node_status} == "Ready" ]]; do
     echo "awaiting node: ${node} to become Ready"
     sleep 10
-    node_status=$(kubectl --context=${kube_context} get node | grep ${node} | awk '{print $2}')
+    node_status=$(kubectl --context="${kube_context}" get node | grep "${node}" | awk '{print $2}')
   done
   # Uncordon the node
-  retry kubectl --context=${kube_context} uncordon ${node}
+  retry kubectl --context="${kube_context}" uncordon "${node}"
 }
 
 cycle_node() {
     local node=$1
 
-    drain_node ${node}
-    wait_until_volumeattachments_drained ${node}
-    reboot_node ${node}
-    wait_for_ready_node ${node}
-    delete_retirement_label ${node}
+    drain_node "${node}"
+    wait_until_volumeattachments_drained "${node}"
+    reboot_node "${node}"
+    wait_for_ready_node "${node}"
+    delete_retirement_label "${node}"
 }
 
 cycle_nodes() {
@@ -238,7 +242,7 @@ cycle_nodes() {
     while [[ $(jobs -p | wc -l) -ge $max_nodes ]]; do
       wait -n
     done
-    cycle_node ${node} &
+    cycle_node "${node}" &
   done
   wait
 }
@@ -246,14 +250,14 @@ cycle_nodes() {
 update() {
   local role=$1
 
-  label_for_cycling ${role}
-  cycle_nodes ${role} ${retire_time}
+  label_for_cycling "${role}"
+  cycle_nodes "${role}" "${retire_time}"
 }
 
 resume() {
   local role=$1
 
-  cycle_nodes ${role} ${resume}
+  cycle_nodes "${role}" "${resume}"
 }
 
 # Cleanup child processes on exit
@@ -262,11 +266,11 @@ trap "kill 0" EXIT
 echo "kube cluster: ${kube_context}"
 
 if [[ -n "${resume}" ]]; then
-  resume ${role}
+  resume "${role}"
   exit 0
 fi
 
-update ${role}
+update "${role}"
 
 echo "run: result=\"success\""
 

--- a/kube-merit-updater
+++ b/kube-merit-updater
@@ -42,7 +42,7 @@ Usage: $0 -c <kube_context> -s [retire_time_label] -r [role]
 EOF
 }
 
-while getopts 'c:r:h:s:t:p:n:' flag; do
+while getopts 'hc:r:s:t:p:n:' flag; do
   case "${flag}" in
     c) kube_context="${OPTARG}" ;;
     r) role="${OPTARG}" ;;

--- a/kube-merit-updater
+++ b/kube-merit-updater
@@ -242,9 +242,21 @@ cycle_nodes() {
     while [[ $(jobs -p | wc -l) -ge $max_nodes ]]; do
       wait -n
     done
-    cycle_node "${node}" &
+    # Run cycle_node in a background job. Redirect stdout and stderr through
+    # 'logger' which adds a timestamp and the node name to each line of output.
+    cycle_node "${node}" > >(logger "${node}") 2> >(logger "${node}" >&2) &
   done
   wait
+}
+
+log() {
+  echo -e "${*}" | logger >&2
+}
+
+logger() {
+    while read -r line; do
+      printf "%(%Y-%m-%dT%H:%M:%S)T [${1:-main}] %s\n" '-1' "${line}"
+    done
 }
 
 update() {
@@ -263,7 +275,7 @@ resume() {
 # Cleanup child processes on exit
 trap "kill 0" EXIT
 
-echo "kube cluster: ${kube_context}"
+log "kube cluster: ${kube_context}"
 
 if [[ -n "${resume}" ]]; then
   resume "${role}"
@@ -272,5 +284,5 @@ fi
 
 update "${role}"
 
-echo "run: result=\"success\""
+log "run: result=\"success\""
 

--- a/kube-merit-updater
+++ b/kube-merit-updater
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Shell style guide: https://google.github.io/styleguide/shell.xml
 
@@ -7,7 +7,8 @@
 #
 # Assumes a kubernetes cluster with master and workers nodes.
 #
-# - drain nodes (sequentially)
+# Performs the following actions concurrently, up to $max_nodes at a time:
+# - drain nodes
 # - reboot nodes and wait until they are back and in `Ready` state
 
 set -o errexit
@@ -20,8 +21,9 @@ readonly retire_time=$(date +"%Y-%m-%dT%H-%M-%SZ")
 kube_context=''
 role=''
 resume=''
-timeout=600
+timeout=''
 socks5_proxy=''
+max_nodes=3
 
 # Static vars
 HTTP_PROXY=''
@@ -29,23 +31,25 @@ HTTP_PROXY=''
 usage() {
   cat <<EOF
 Usage: $0 -c <kube_context> -s [retire_time_label] -r [role]
-        -t [timeout]
+        -t [timeout] -n [max_nodes]
 
   -s    Resume node rolling. Argument is retire_time label. If set, -r [role]
         must also be set
   -t    Node drain timeout. How long to wait for the node to drain before
-        shutting it down (in seconds, default 300s)
+        shutting it down (in seconds, default 600s*max_nodes)
   -p    Specify a socks5 proxy for kubectl commands <address>:<port>
+  -n    The maximum number of nodes that are permitted to be rolled at once (default 3)
 EOF
 }
 
-while getopts 'c:r:h:s:t:p:' flag; do
+while getopts 'c:r:h:s:t:p:n:' flag; do
   case "${flag}" in
     c) kube_context="${OPTARG}" ;;
     r) role="${OPTARG}" ;;
     s) resume="${OPTARG}" ;;
     t) timeout="${OPTARG}" ;;
     p) socks5_proxy="${OPTARG}" ;;
+    n) max_nodes="${OPTARG}" ;;
     h) usage && exit 0 ;;
     *) echo "Unexpected option: ${flag}" && usage && exit 1 ;;
   esac
@@ -82,8 +86,21 @@ else
 fi
 export HTTP_PROXY=${HTTP_PROXY}
 
+# If a timeout isn't set then default to 10m * the max number of nodes that may
+# be draining concurrently. This affords the same timeout to pods covered by the
+# same PDB.
+if [[ -z "${timeout}" ]]; then
+  timeout=$((600*max_nodes))
+fi
+
 ### Validation
 if [[ -z "${kube_context}" ]]; then
+  usage
+  exit 1
+fi
+
+if [[ "${max_nodes}" -lt 1 ]]; then
+  echo "Max nodes must be >=1: ${max_nodes}"
   usage
   exit 1
 fi
@@ -149,7 +166,7 @@ drain_node() {
   local node=$1
 
   set +e
-  time timeout ${timeout} kubectl --context=${kube_context} drain ${node} --ignore-daemonsets --force --delete-local-data
+  time timeout --foreground ${timeout} kubectl --context=${kube_context} drain ${node} --ignore-daemonsets --force --delete-local-data
   local rc=$?
   if [[ ${rc} -eq 0 ]]; then
     echo "drained successfully"
@@ -201,41 +218,46 @@ wait_for_ready_node() {
   retry kubectl --context=${kube_context} uncordon ${node}
 }
 
-cycle_nodes() {
-  local role=$1
+cycle_node() {
+    local node=$1
 
-  # - drain and reboot nodes (sequentially)
-  local nodes=$(retry kubectl --context="${kube_context}" get nodes -l role="${role}",retiring="${retire_time}" -o json |\
-    jq -r '.items[].metadata.name')
-  for node in ${nodes}; do
     drain_node ${node}
     wait_until_volumeattachments_drained ${node}
     reboot_node ${node}
     wait_for_ready_node ${node}
     delete_retirement_label ${node}
+}
+
+cycle_nodes() {
+  local role=$1
+  local retiring=$2
+
+  nodes=$(retry kubectl --context="${kube_context}" get nodes -l role="${role}",retiring="${retiring}" -o json |\
+    jq -r '.items[].metadata.name')
+  for node in ${nodes}; do
+    while [[ $(jobs -p | wc -l) -ge $max_nodes ]]; do
+      wait -n
+    done
+    cycle_node ${node} &
   done
+  wait
 }
 
 update() {
   local role=$1
+
   label_for_cycling ${role}
-  cycle_nodes ${role}
+  cycle_nodes ${role} ${retire_time}
 }
 
 resume() {
   local role=$1
 
-  local target_nodes=$(retry kubectl --context="${kube_context}" get nodes -l role="${role}",retiring="${resume}" -o json |\
-    jq -r '.items[].metadata.name')
-  for target_node in ${target_nodes}; do
-    drain_node ${target_node}
-    wait_until_volumeattachments_drained ${target_node}
-    reboot_node ${target_node}
-    wait_for_ready_node ${target_node}
-    delete_retirement_label ${target_node}
-  done
-
+  cycle_nodes ${role} ${resume}
 }
+
+# Cleanup child processes on exit
+trap "kill 0" EXIT
 
 echo "kube cluster: ${kube_context}"
 

--- a/kube-merit-updater
+++ b/kube-merit-updater
@@ -31,7 +31,7 @@ HTTP_PROXY=''
 usage() {
   cat <<EOF
 Usage: $0 -c <kube_context> -s [retire_time_label] -r [role]
-        -t [timeout] -n [max_nodes]
+        -t [timeout] -p [socks5_proxy] -n [max_nodes]
 
   -s    Resume node rolling. Argument is retire_time label. If set, -r [role]
         must also be set


### PR DESCRIPTION
- Cycle each node in a background job
- Only allow up to `$max_nodes` jobs to run concurrently. Move onto the next node when a job finishes. 
- The value of `$max_nodes` is controlled by the `-n` flag.
- By default, calculate the timeout in respect to the value of `$max_nodes` (`10m*$max_nodes`). This accounts for PDBs.
- Prepend a timestamp and the node name to each line of output. This makes it possible to identify which messages belong to which node and filter the output by node:
  ```
  2021-01-25T10:16:02 [worker-10.dev.merit.uw.systems] pod/gatekeeper-controller-manager-76d956d6c4-vwxqr evicted
  2021-01-25T10:16:02 [worker-10.dev.merit.uw.systems] pod/cert-manager-65b665b74d-jtz6f evicted
  2021-01-25T10:16:03 [worker-10.dev.merit.uw.systems] pod/cert-manager-webhook-7db5f95d48-kspzw evicted
  2021-01-25T10:16:03 [worker-0.dev.merit.uw.systems] awaiting node: worker-0.dev.merit.uw.systems to become Ready
  ```

Uses features of `wait` and `printf` that are only available in bash versions `>=4`, so I've added a check to block older versions.

Other changes:
- I ran shellcheck and implemented its suggestions
- Fixed the `-h` flag, which was expecting input