### PR TITLE
Reduce max_nodes default to 1

### DIFF
--- a/kube-merit-updater
+++ b/kube-merit-updater
@@ -23,7 +23,7 @@ role=''
 resume=''
 timeout=''
 socks5_proxy=''
-max_nodes=3
+max_nodes=1
 
 # Static vars
 HTTP_PROXY=''
@@ -38,7 +38,7 @@ Usage: $0 -c <kube_context> -s [retire_time_label] -r [role]
   -t    Node drain timeout. How long to wait for the node to drain before
         shutting it down (in seconds, default 600s*max_nodes)
   -p    Specify a socks5 proxy for kubectl commands <address>:<port>
-  -n    The maximum number of nodes that are permitted to be rolled at once (default 3)
+  -n    The maximum number of nodes that are permitted to be rolled at once (default 1)
 EOF
 }
 


### PR DESCRIPTION
We run 5 masters in our merit clusters. Losing 3 of those to reboots at the same time is a pretty significant drop in capacity.

In general, you would expect the script to have 'safe' defaults that you can just run without examining. Rather than special casing the default for masters, I think it's better to just set a low default and let the user decide the amount of capacity they can lose depending on the env they're in and what they're trying to achieve.